### PR TITLE
[FRONT-267]: cards library — hide canned services

### DIFF
--- a/src/views/WorkOrder/VehicleHealth/AddCard/index.vue
+++ b/src/views/WorkOrder/VehicleHealth/AddCard/index.vue
@@ -8,12 +8,6 @@
       </div>
       <Input icon-left="i-search1" placeholder="Start typing to search card" />
       <div class="modal__block">
-        <div class="modal__block-title">CANNED SERVICES</div>
-        <div class="modal__block-inner">
-          <Service viewOnly />
-          <Service viewOnly />
-          <Service viewOnly />
-        </div>
         <div class="modal__block-title">CARDS</div>
         <div class="modal__block-inner">
           <Card v-for="card of cards" :key="card.templateID" :card="card" @click="openCard(card)" />


### PR DESCRIPTION
https://linear.app/asntech/issue/FRONT-267/cards-library-hide-canned-services
![Screenshot 2022-10-30 at 12 32 00](https://user-images.githubusercontent.com/39219794/198887510-dcb2169e-be02-4ef7-bb15-5c168d706355.png)
