### PR TITLE
[FRONT-268]: remove additional info tab from card in vehicle health

### DIFF
--- a/src/views/WorkOrder/VehicleHealth/CardPage/index.vue
+++ b/src/views/WorkOrder/VehicleHealth/CardPage/index.vue
@@ -30,7 +30,6 @@
           <div v-if="block !== 'Service'" class="blocks__subtitle">{{ card.description }}</div>
           <div v-if="block !== 'Service'" class="blocks__nav">
             <button class="blocks__btn" :class="{'-green': block === 'General'}" @click="block = 'General'">General</button>
-            <button class="blocks__btn" :class="{'-green': block === 'Additional'}" @click="block = 'Additional'">Additional Info</button>
             <button class="blocks__btn" :class="{'-green': block === 'Notes'}" @click="block = 'Notes'">Notes</button>
             <button class="blocks__btn" :class="{'-green': block === 'Tracking'}" @click="block = 'Tracking'">Service Tracking</button>
             <button class="blocks__btn" :class="{'-green': block === 'Media'}" @click="block = 'Media'">Media</button>


### PR DESCRIPTION
https://linear.app/asntech/issue/FRONT-268/remove-additional-info-tab-from-card-in-vehicle-health
![Screenshot 2022-10-30 at 12 38 54](https://user-images.githubusercontent.com/39219794/198887546-4208f44e-e7ae-4759-b719-b83b5b53b8ce.png)
